### PR TITLE
removed the scroll bar from the site

### DIFF
--- a/index.css
+++ b/index.css
@@ -17,6 +17,20 @@ body {
     color: white;
 }
 
+
+/* Alternative approach using ::-webkit-scrollbar pseudo-element */
+body::-webkit-scrollbar {
+    width: 0.5em;
+    /* Set the width of the scrollbar */
+    background-color: #F5F5F5;
+    /* Set the background color of the scrollbar */
+}
+
+body::-webkit-scrollbar-thumb {
+    background-color: #000000;
+    /* Set the color of the scrollbar thumb */
+}
+
 button {
     background-color: #FFF100;
     cursor: pointer;

--- a/index.js
+++ b/index.js
@@ -77,3 +77,5 @@ function determineCardWinner(card1, card2) {
     }
 }
 
+/* JavaScript approach to disable scrolling */
+document.body.style.overflow = "hidden";


### PR DESCRIPTION
1) Added CSS for customizing the scrollbar:
body::-webkit-scrollbar {
    width: 0.5em;
    /* Set the width of the scrollbar */
    background-color: #F5F5F5;
    /* Set the background color of the scrollbar */
}

body::-webkit-scrollbar-thumb {
    background-color: #000000;
    /* Set the color of the scrollbar thumb */
}
These CSS rules customize the appearance of the scrollbar in webkit-based browsers (such as Chrome and Safari). The ::-webkit-scrollbar selector targets the scrollbar itself, and ::-webkit-scrollbar-thumb targets the thumb (the draggable part of the scrollbar).

2) Applied overflow: hidden; to the body using JavaScript:
`Applied overflow: hidden; to the body using JavaScript:`
This line of JavaScript code sets the overflow property of the body element to "hidden", effectively hiding the scrollbar. By modifying the style of the body element directly using the style property, you can dynamically change the CSS properties of the element.

By combining the CSS customization for the scrollbar with JavaScript to set overflow: hidden;, you have customized the appearance of the scrollbar and hidden it from view.
